### PR TITLE
ルート、レイアウトなど微調整

### DIFF
--- a/app/models/cart.rb
+++ b/app/models/cart.rb
@@ -4,7 +4,7 @@ class Cart < ApplicationRecord
   belongs_to :item
 
   def subtotal
-    item.with_tax_price * quantity　#これで各商品の小計でる。
+    item.with_tax_price * quantity#これで各商品の小計でる。
   end
 
 end

--- a/app/views/public/cart_items/index.html.erb
+++ b/app/views/public/cart_items/index.html.erb
@@ -45,7 +45,7 @@
  <div>
      <div><%= link_to "カートを空にする", public_cart_items_path, class: "btn btn-danger", method: :delete %> </div>
      <div><%= link_to "買い物を続ける", public_items_path(@cart_item), class: "btn btn-primary" %></div>
-     <div><%= link_to "情報入力に進む", class: "btn btn-success" %></div>
+     <div><%= link_to "情報入力に進む", new_public_order_path, class: "btn btn-success" %></div>
  </div>
 
 </div>

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,9 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-
 ActiveRecord::Schema.define(version: 2022_01_23_044635) do
-
 
   create_table "addresses", force: :cascade do |t|
     t.datetime "created_at", null: false
@@ -100,12 +98,8 @@ ActiveRecord::Schema.define(version: 2022_01_23_044635) do
     t.integer "status"
     t.integer "payment_method"
     t.datetime "created_at"
-
-
-    t.datetime "updated_at", null: false
-    t.integer "member_id", null: false
-
-
+    t.datetime "updated_at"
+    t.integer "member_id"
   end
 
 end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -97,8 +97,8 @@ ActiveRecord::Schema.define(version: 2022_01_23_044635) do
     t.integer "total_payment"
     t.integer "status"
     t.integer "payment_method"
-    t.datetime "created_at"
-    t.datetime "updated_at"
+    t.datetime "created_at", null: false
+    t.datetime "updated_at", null: false
     t.integer "member_id"
   end
 


### PR DESCRIPTION
カートモデルに全角スペースがあったので削除しました。
cart_items.indexにルートを追記しました。
cart_items.indexにbootstrapを使用します。

